### PR TITLE
fix: Enable feedback buttons in daily notifications

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -29,7 +29,7 @@ class PaperSummarizerPipeline:
         self.rss_fetcher = RSSFetcher()
         self.content_fetcher = ContentFetcher(debug_mode=debug_mode)
         self.summarizer = Summarizer(debug_mode=debug_mode)
-        self.slack_notifier = SlackNotifier()
+        self.slack_notifier = SlackNotifier(enable_feedback=True)
         self.queue_manager = QueueManager()
         self.archive_manager = ArchiveManager()
         self.filter_config_file = "data/filter_config.json"


### PR DESCRIPTION
## 問題
毎日朝7時の定期実行でSlack通知にフィードバックボタンが表示されていませんでした。

## 原因
SlackNotifierの初期化時にenable_feedback=Trueが設定されていなかったため。

## 修正内容
- src/main.pyの32行目でSlackNotifier(enable_feedback=True)に変更
- これにより全ての定期実行でフィードバックボタンが表示されるようになります

## テスト
以下のコマンドでローカルテスト可能:
python src/main.py --slack-test-3