### PR TITLE
feat: Increase batch size from 10 to 20 articles

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -487,7 +487,7 @@ class PaperSummarizerPipeline:
             self.show_queue_stats()
             
             # 処理対象記事を取得
-            articles_to_process = self.queue_manager.get_batch(batch_size=10)
+            articles_to_process = self.queue_manager.get_batch(batch_size=20)
             total_articles = articles_to_process
             
             if not total_articles:


### PR DESCRIPTION
## 変更内容
バッチサイズを10から20に増やしました。

## 背景
現在の設定では10記事取得してもフィルタリング後に4記事程度しか通知されないため、より多くの記事を処理できるようにバッチサイズを増やしました。

## 詳細
- src/main.py の490行目で batch_size=10 を batch_size=20 に変更
- フィルタリング前により多くの記事を処理することで、フィルタリング後の記事数も増加が期待できます

## 影響
- 1回の実行でより多くの記事が処理されます
- API使用量が増加する可能性があります（Gemini APIの無料枠内での運用に注意）